### PR TITLE
Add an MRE

### DIFF
--- a/src/tests/fixtures/checkbox_checked.html
+++ b/src/tests/fixtures/checkbox_checked.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html id="html" data-skip-event-details="turbo:submit-start turbo:submit-end turbo:fetch-request-error">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="turbo-refresh-scroll" content="preserve">
+
+  <title>Turbo</title>
+  <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+  <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+  <script src="/src/tests/fixtures/test.js"></script>
+
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+
+      /* Ensure the page is large enough to scroll */
+      width: 150vw;
+      height: 150vh;
+    }
+  </style>
+</head>
+
+<body>
+  <form id="form" action="/__turbo/uncheck" method="post" class="redirect">
+    <input id="form-checkbox" type="checkbox" checked="checked" name="checkbox">
+    <input type="hidden" name="path" value="/src/tests/fixtures/checkbox_unchecked.html">
+    <input type="hidden" name="sleep" value="50">
+    <input id="form-submit" type="submit" value="form[method=post]">
+  </form>
+</body>
+
+</html>

--- a/src/tests/fixtures/checkbox_unchecked.html
+++ b/src/tests/fixtures/checkbox_unchecked.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html id="html" data-skip-event-details="turbo:submit-start turbo:submit-end turbo:fetch-request-error">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="turbo-refresh-scroll" content="preserve">
+
+  <title>Turbo</title>
+  <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+  <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+  <script src="/src/tests/fixtures/test.js"></script>
+
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+
+      /* Ensure the page is large enough to scroll */
+      width: 150vw;
+      height: 150vh;
+    }
+  </style>
+</head>
+
+<body>
+  <form id="form" action="/__turbo/check" method="post" class="redirect">
+    <input id="form-checkbox" type="checkbox" name="checkbox">
+    <input type="hidden" name="path" value="/src/tests/fixtures/checkbox_checked.html">
+    <input type="hidden" name="sleep" value="50">
+    <input id="form-submit" type="submit" value="form[method=post]">
+  </form>
+</body>
+
+</html>

--- a/src/tests/functional/page_refresh_tests.js
+++ b/src/tests/functional/page_refresh_tests.js
@@ -8,8 +8,10 @@ import {
   nextEventOnTarget,
   noNextEventOnTarget,
   noNextEventNamed,
+  sleep,
   getSearchParam,
-  refreshWithStream
+  refreshWithStream,
+  reloadPage
 } from "../helpers/page"
 
 test("renders a page refresh with morphing", async ({ page }) => {
@@ -18,6 +20,58 @@ test("renders a page refresh with morphing", async ({ page }) => {
   await page.click("#form-submit")
   await nextEventNamed(page, "turbo:before-render", { renderMethod: "morph" })
   await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+})
+
+test("renders a page soft-reload with checkboxes", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/checkbox_unchecked.html")
+
+  await page.check("#form-checkbox")
+  await page.click("#form-submit")
+
+  await nextBody(page)
+
+  expect(await page.url()).toMatch(/checkbox_checked\.html/)
+  expect(await page.isChecked("#form-checkbox")).toBeTruthy()
+
+  await page.uncheck("#form-checkbox")
+  await page.click("#form-submit")
+
+  await nextBody(page)
+
+  expect(await page.url()).toMatch(/checkbox_unchecked\.html/)
+  expect(await page.isChecked("#form-checkbox")).toBeFalsy()
+
+  await reloadPage(page)
+  await nextBody(page)
+
+  expect(await page.url()).toMatch(/checkbox_unchecked\.html/)
+  expect(await page.isChecked("#form-checkbox")).toBeFalsy()
+})
+
+test("renders a page hard-reload with checkboxes", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/checkbox_unchecked.html")
+
+  await page.check("#form-checkbox")
+  await page.click("#form-submit")
+
+  await nextBody(page)
+
+  expect(await page.url()).toMatch(/checkbox_checked\.html/)
+  expect(await page.isChecked("#form-checkbox")).toBeTruthy()
+
+  await page.uncheck("#form-checkbox")
+  await page.click("#form-submit")
+
+  await nextBody(page)
+
+  expect(await page.url()).toMatch(/checkbox_unchecked\.html/)
+  expect(await page.isChecked("#form-checkbox")).toBeFalsy()
+
+  await page.reload()
+  await nextBody(page)
+
+  expect(await page.url()).toMatch(/checkbox_unchecked\.html/)
+  expect(await page.isChecked("#form-checkbox")).toBeFalsy()
 })
 
 test("async page refresh with turbo-stream", async ({ page }) => {

--- a/src/tests/server.mjs
+++ b/src/tests/server.mjs
@@ -54,6 +54,26 @@ router.post("/refresh", (request, response) => {
   setTimeout(() => response.redirect("back"), parseInt(sleep || "0", 10))
 })
 
+router.post("/check", (request, response) => {
+  const { path, ...query } = request.query
+  const pathname = path ?? "/src/tests/fixtures/checkbox_checked.html"
+  const enctype = request.get("Content-Type")
+  if (enctype) {
+    query.enctype = enctype
+  }
+  response.redirect(301, url.format({ pathname, query }))
+})
+
+router.post("/uncheck", (request, response) => {
+  const { path, ...query } = request.query
+  const pathname = path ?? "/src/tests/fixtures/checkbox_unchecked.html"
+  const enctype = request.get("Content-Type")
+  if (enctype) {
+    query.enctype = enctype
+  }
+  response.redirect(301, url.format({ pathname, query }))
+})
+
 router.post("/reject/tall", (request, response) => {
   const { status } = request.body
   const fixture = path.join(__dirname, `../../src/tests/fixtures/422_tall.html`)
@@ -109,7 +129,7 @@ router.post("/refreshes", (request, response) => {
   const params = { ...request.body, ...request.query }
   const { requestId } = params
 
-  if(acceptsStreams(request)){
+  if (acceptsStreams(request)) {
     response.type("text/vnd.turbo-stream.html; charset=utf-8")
     response.send(renderPageRefresh(requestId))
   } else {


### PR DESCRIPTION
<!---
Thanks for submitting a pull request!

The prompts below (the _bits in italics_) are for guidance to help you describe your change in a way that is most likely to make sense to other people when they are reviewing it. Still, it's just a guide, so feel free to delete anything that doesn't feel appropriate, and add anything additional that seems like it would probide useful context.

Please either replace the promopts with your own words, or delete them.
-->

# Description

This is a Minimal Reproducible Example of an issue faced with checkboxes and Firefox.

When changing the status of a checkbox two times, then reloading the page (using a "soft" reload, withthout "Ctrl+R"), the checkbox "checked" status is not the expected one.

It is pretty difficult to explain, this is why I crafted a reproducible example

```javascript
test("renders a page soft-reload with checkboxes", async ({ page }) => {
  await page.goto("/src/tests/fixtures/checkbox_unchecked.html")

  await page.check("#form-checkbox")
  await page.click("#form-submit")

  await nextBody(page)

  expect(await page.url()).toMatch(/checkbox_checked\.html/)
  expect(await page.isChecked("#form-checkbox")).toBeTruthy()

  await page.uncheck("#form-checkbox")
  await page.click("#form-submit")

  await nextBody(page)

  expect(await page.url()).toMatch(/checkbox_unchecked\.html/)
  expect(await page.isChecked("#form-checkbox")).toBeFalsy()

  await reloadPage(page)
  await nextBody(page)

  expect(await page.url()).toMatch(/checkbox_unchecked\.html/)
  expect(await page.isChecked("#form-checkbox")).toBeFalsy()
})
```

On Firefox, the last expectation is failing.
